### PR TITLE
Add getStateCode(), which allows users to look up the code of a state based on its name

### DIFF
--- a/src/CountryState.php
+++ b/src/CountryState.php
@@ -66,6 +66,30 @@ class CountryState
         }
     }
 
+    /**
+     * Pass a country code to search a single country or an array of codes to search several countries in the order given
+     * If $country is null all countries will be searched, which can be slow.
+     *
+     * @param string $lookFor
+     * @param mixed $country
+     * @return string|null
+     */
+    public function getStateCode($lookFor, $country = null)
+    {
+        $lookFor = mb_strtoupper($lookFor);
+        $countries = is_null($country) ? array_keys($this->countries) : (array)$country;
+
+        foreach ($countries as $countryCode) {
+            $states = array_map('mb_strtoupper', $this->findCountryStates($countryCode));
+
+            if ($code = array_search($lookFor, $states)) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+
     protected function findCountryStates($country)
     {
         if (!array_key_exists($country, $this->states)) {


### PR DESCRIPTION
The function is fairly straightforward: I cast the names of the states and the needle to uppercase to avoid "NEW YORK" not resolving to "NY", and I give the user the ability to control what will be searched. If nothing matches up I return null, to be consistent with getStateName().
