### PR TITLE
Update composer to use correct version of rinvex/country

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.0",
         "illuminate/support": "~5.1",
-        "rinvex/country": "~3.0"
+        "rinvex/country": "3.0.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",


### PR DESCRIPTION
Newest version of rinvex/country changes the Loader class to CountryLoader. This change reverts to the compatible version of rinvex/country.