### PR TITLE
Fixed issue with CountryLoader being changed - Rinvex Fault

### DIFF
--- a/src/CountryState.php
+++ b/src/CountryState.php
@@ -4,7 +4,7 @@ namespace DougSisk\CountryState;
 
 use Exception;
 use Rinvex\Country\Country;
-use Rinvex\Country\Loader;
+use Rinvex\Country\CountryLoader as Loader;
 
 class CountryState
 {


### PR DESCRIPTION
This seems to be causing an issue when i install it right now - Not quite sure why but when i pulled in through composer this issue exists.

https://github.com/rinvex/country/tree/master/src

See the link - Loader Class no longer exists.