### PR TITLE
Fix bug that will cause failure for countries without subdivisions

### DIFF
--- a/src/CountryState.php
+++ b/src/CountryState.php
@@ -38,7 +38,7 @@ class CountryState
         }
 
         $this->setLanguage($language);
-        
+
         if ($preloadCountryStates) {
             foreach ($preloadCountryStates as $country) {
                 $this->addCountryStates($country);
@@ -175,9 +175,11 @@ class CountryState
         $this->states[$countryCode] = [];
         $states = $country->getDivisions();
 
-        foreach ($states as $code => $division) {
-            $code = preg_replace("/([A-Z]{2}-)/", '', $code);
-            $this->states[$countryCode][$code] = $division['name'];
+        if( !is_null($states) ) {
+            foreach ($states as $code => $division) {
+                $code = preg_replace("/([A-Z]{2}-)/", '', $code);
+                $this->states[$countryCode][$code] = $division['name'];
+            }
         }
     }
 }

--- a/tests/CountryStateTest.php
+++ b/tests/CountryStateTest.php
@@ -31,6 +31,13 @@ class CountryStateTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hawaii', $states['HI']);
     }
 
+    public function testGetCountryStatesForCountriesWithoutStates()
+    {
+        $states = $this->countryState->getStates('AW');
+
+        $this->assertEmpty($states);
+    }
+
     public function testGetStateCode()
     {
         $stateCode = $this->countryState->getStateCode('Hawaii', 'US');


### PR DESCRIPTION
The phine loader would return an empty array if no states were found

https://github.com/kherge-abandoned/lib-country/blob/master/src/lib/Phine/Country/Loader/Loader.php#L147

While the rinvex getDivisions method will return null

https://github.com/rinvex/country/blob/master/src/Country.php#L866

Thus the `Country::addCountryStates` method will fail if a country has no further administrative subdivisions (really common).

This PR fixes that by wrapping the foreach in a null check.